### PR TITLE
Fix browser action popup player controls

### DIFF
--- a/scripts/myscript.js
+++ b/scripts/myscript.js
@@ -407,16 +407,16 @@ function fetch_playlists(request, callback) {
 function playback_action(type, callback) {
   var $button;
   if (type == 'playPause') {
-    $button = $('button[data-id="play-pause"]');
+    $button = $('sj-icon-button[data-id="play-pause"]');
   }
   else if (type == 'nextSong') {
-    $button = $('button[data-id="forward"]');
+    $button = $('sj-icon-button[data-id="forward"]');
   }
   else if (type == 'prevSong') {
-    $button = $('button[data-id="rewind"]');
+    $button = $('sj-icon-button[data-id="rewind"]');
   }
   else if (type == 'currently_playing') {
-    $button = $('button[data-id="play-pause"]');
+    $button = $('sj-icon-button[data-id="play-pause"]');
   }
   if ($('button[data-id="play-pause"]').attr('disabled')) {
     $instant_mix = $('li[data-type="rd"]').click();

--- a/scripts/track.js
+++ b/scripts/track.js
@@ -9,13 +9,13 @@ var Track = {
 	status : '',
 
 	now_playing : function() {
-		this.song_title = $("#playerSongTitle").text();
+		this.song_title = $("#player-song-title").text();
 		this.artist = $("#player-artist").text();
 		this.album_art = $("#playingAlbumArt").attr('src');
 		this.current_time = $("#time_container_current").text();
 		this.total_time = $("#time_container_duration").text();
 		var status = 'Play';
-		if ($('button[data-id="play-pause"]').hasClass('playing')) {
+		if ($('sj-icon-button[data-id="play-pause"]').hasClass('playing')) {
 			// console.log('this is playing');
 			status = 'Pause';
 		}


### PR DESCRIPTION
Quick fix to restore functionality to browser action popup controls after Google Play Music Material redesign on web interface. Still somewhat buggy (Next/Previous buttons don't play nice when playback is paused) but better than it was. Also contains a fix for song title display in browser action popup